### PR TITLE
Override the Alexa display category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### New features
-- Added ability to override the Alexa display category from a custom Vera device variable:
+- Added ability to override the Alexa display category from a custom Vera device variable [#2](https://github.com/cgmartin/custom-vera-skill/pull/2):
     ```
     # Under Devices -> {Device} -> Advanced -> New Service (tab)
     New service: urn:cgmartin-com:serviceId:SmartHomeSkill1
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v1.0.1] - 2017-11-12
 ### Internal refactor
-- Refactored handlers to use a promise API.
+- Refactored handlers to use a promise API [#1](https://github.com/cgmartin/custom-vera-skill/pull/1).
 - No new features or fixes.
 
 ## v1.0.0 - 2017-11-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## v1.1.0-beta - [Unreleased]
 ### New features
 - Added ability to override the Alexa display category from a custom Vera device variable [#2](https://github.com/cgmartin/custom-vera-skill/pull/2):
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### New features
+- Added ability to override the Alexa display category from a custom Vera device variable:
+    ```
+    # Under Devices -> {Device} -> Advanced -> New Service (tab)
+    New service: urn:cgmartin-com:serviceId:SmartHomeSkill1
+    New variable: DisplayCategory
+    New value: LIGHT
+    ```
+
 ## [v1.0.1] - 2017-11-12
 ### Internal refactor
 - Refactored handlers to use a promise API.
@@ -14,5 +24,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Initial release
 - See README.md for setup instructions.
 
-
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.1...HEAD
 [v1.0.1]: https://github.com/cgmartin/custom-vera-skill/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -254,6 +254,21 @@ The Amazon Alexa Developer docs have [step-by-step instructions](https://develop
 
 You can use the following URL for a privacy policy link in Step 1: <https://raw.githubusercontent.com/cgmartin/custom-vera-skill/master/lwa/privacy-policy.html>
 
+## Alexa-enabled groups
+
+> With Alexa-enabled Groups, customers no longer need to remember the specific name of a smart device or group of smart devices to control them. A customer can now include their Echo devices in specific smart home groups, enabling Alexa to act more intelligently on requests. For example, when a customer walks into the living room, they can say, “Alexa, turn on the lights” rather than “Alexa, turn on the living room lights.”
+
+~ from [Alexa Blogs](https://developer.amazon.com/blogs/alexa/post/0a55ae8a-1f39-411f-a3ca-6a19be80b2f3/now-available-routines-alexa-enabled-groups-and-smart-home-device-state-in-the-amazon-alexa-app) November 02, 2017
+
+For the Alexa-enabled group "turn on the lights" feature to work, devices must be discovered as a LIGHT [display category](https://developer.amazon.com/docs/device-apis/alexa-discovery.html#display-categories), as opposed to a SWITCH (or other types). Basing this off of the Vera `category_num` and `subcategory_num` can be problematic (is the internal switch a light or something else?). This project makes a best guess from the category/subcategory, but you can also explicitly set the Alexa display category by adding a new custom variable:
+
+```
+# Under Devices -> {Device} -> Advanced -> New Service (tab)
+New service: urn:cgmartin-com:serviceId:SmartHomeSkill1
+New variable: DisplayCategory
+New value: LIGHT
+```
+
 ## License
 
 [MIT License](./LICENSE.txt)

--- a/handlers/discovery-handler.js
+++ b/handlers/discovery-handler.js
@@ -101,6 +101,7 @@ function createDimmerEndpoint(d, cInfo, udata) {
     case 3: displayCategory = 'SWITCH'; break;
     case 4: displayCategory = 'LIGHT'; break;
   }
+  displayCategory = getDisplayCategoryOverride(d, displayCategory);
 
   const endpoint = createStandardDeviceEndpointProps('Dimmable Light', displayCategory, d, cInfo, udata);
   endpoint.capabilities = [
@@ -130,6 +131,7 @@ function createSwitchEndpoint(d, cInfo, udata) {
     case 5: displayCategory = 'SWITCH'; break;
     case 6: displayCategory = 'SWITCH'; break;
   }
+  displayCategory = getDisplayCategoryOverride(d, displayCategory);
 
   const endpoint = createStandardDeviceEndpointProps('Switch', displayCategory, d, cInfo, udata);
   endpoint.capabilities = [
@@ -256,4 +258,12 @@ function createCameraStreamDiscoveryCapability(d) {
 function getRoomNameFromId(rId, rooms) {
   const room = rooms.find((r) => Number(r.id) === Number(rId));
   return (room) ? room['name'] : null;
+}
+
+function getDisplayCategoryOverride(d, defaultCategory) {
+  if (!d.states) return defaultCategory;
+  const override = d.states.find((s) =>
+    (s.service === 'urn:cgmartin-com:serviceId:SmartHomeSkill1' && s.variable === 'DisplayCategory')
+  );
+  return (override) ? override.value : defaultCategory;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-vera-skill",
-  "version": "1.0.1",
+  "version": "1.1.0-beta",
   "description": "Unofficial custom Smart Home v3 skill for Vera controllers",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
- Added ability to override the Alexa display category from a custom Vera device variable:
    ```
    # Under Devices -> {Device} -> Advanced -> New Service (tab)
    New service: urn:cgmartin-com:serviceId:SmartHomeSkill1
    New variable: DisplayCategory
    New value: LIGHT
    ```