### PR TITLE
Forbid use of insecure scenes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -240,7 +240,7 @@ module.exports = {
         ],
         "valid-jsdoc": "off",
         "vars-on-top": "error",
-        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
         "wrap-iife": "error",
         "wrap-regex": "error",
         "yield-star-spacing": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Bug fixes
+- Fixed: Colored Bulb Device adjust temperature - incorrect error handling when device status is missing
+
+### New features
+- Forbids discovery and usage of Scenes that include [insecure devices](https://developer.amazon.com/docs/smarthome/provide-scenes-in-a-smart-home-skill.html#scene-discovery-and-allowed-devices) [#5](https://github.com/cgmartin/custom-vera-skill/pull/5).
+
+### Changes
+- Session cache will not be cleared during Discovery in this release. Discovery events occur more frequently than expected - cache helps reduce the lambda execution time for this heavy operation. If this becomes problematic, may need to clear the cache in certain error scenarios.
+
+
 ## [v1.1.0] - 2017-11-19
 ### Bug fixes
 - Fixed: Alexa gives an error when adjusting a dimmer out of range [#3](https://github.com/cgmartin/custom-vera-skill/issues/3)
@@ -30,5 +41,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Initial release
 - See README.md for setup instructions.
 
+[Unreleased]: https://github.com/cgmartin/custom-vera-skill/compare/v1.1.0...HEAD
 [v1.1.0]: https://github.com/cgmartin/custom-vera-skill/compare/v1.0.1...v1.1.0
 [v1.0.1]: https://github.com/cgmartin/custom-vera-skill/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ This Open Source Software (OSS) project is not affiliated with, endorsed, or spo
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-**NOTE**: Do not submit this Smart Home skill for certification. This skill is intended for personal use only and should not be released on the Alexa Skills Marketplace:
+**NOTE**: Do not submit this Smart Home skill for certification. This skill is intended for personal use only and should not be released on the Alexa Skills Marketplace.
 
-- Only a single Vera user is supported. Unless you want the world controlling your home devices, multi-user authentication and other implementation changes would be required for a public skill.
-- Vera Scenes are not currently being checked for [secure devices](https://developer.amazon.com/docs/smarthome/provide-scenes-in-a-smart-home-skill.html#allowed-devices) and would not pass the Skill approval process. Do not put Door Locks or other sensitive devices that could be misued from Alexa within your Vera Scenes. Again, use at your own risk.
 
 ## What is Supported
 
@@ -121,8 +119,6 @@ These instructions will get a copy of the project up and running on your local m
 Setting up a S3 bucket to cache Vera auth sessions and device information will help speed up typical requests from ~3 seconds to ~1 second (based on my personal tests). If interested in using a different storage system, look at  `./lib/s3-vera-cache.js` for an example to base your implementation on.
 
 Without a cache, the Lambda function will need to authenticate, retrieve controller information, and create new sessions with the Vera servers for every request. This requires 6 HTTP requests at a minimum to be sent to the Vera Servers before sending other actions to your Controller. The Alexa application UI prefers quick responses and may display a temporary "This device is unresponsive" message when things aren't returned within ~2 seconds.
-
-**NOTE:** The cache will be cleared upon any Discovery events. If you experience any issues with normal usage, you can try rediscovering your devices from the Alexa app to clear the cache.
 
 The next sections assume you have the AWS CLI installed and [configured with your AWS credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html).
 

--- a/handlers/brightness-handler.js
+++ b/handlers/brightness-handler.js
@@ -19,7 +19,7 @@ module.exports = function brightnessHandler(vera, request) {
 
 function changeBrightness(d, sData, cInfo, directive, payload, vera) {
   // Verify that the device is capable of power on/off actions
-  if ([2].indexOf(Number(d.category)) === -1) {
+  if (Number(d.category) !== 2) {
     return Promise.reject(utils.error('INVALID_VALUE', `Directive is not supported for this device: ${d.id}`));
   }
 

--- a/handlers/color-handler.js
+++ b/handlers/color-handler.js
@@ -19,7 +19,7 @@ module.exports = function colorHandler(vera, request) {
 
 function changeColor(d, sData, cInfo, directive, payload, vera) {
   // Verify that the device is capable of power on/off actions
-  if ([2].indexOf(Number(d.category)) === -1) {
+  if (Number(d.category) !== 2 || Number(d.subcategory) !== 4) {
     return Promise.reject(utils.error('INVALID_VALUE', `Directive is not supported for this device: ${d.id}`));
   }
 

--- a/handlers/lock-handler.js
+++ b/handlers/lock-handler.js
@@ -18,7 +18,7 @@ module.exports = function lockHandler(vera, request) {
 
 function changeLock(d, sData, cInfo, directive, vera) {
   // Verify that the device is capable of power on/off actions
-  if ([7].indexOf(Number(d.category)) === -1) {
+  if (Number(d.category) !== 7) {
     return Promise.reject(utils.error('INVALID_VALUE', `Directive is not supported for this device: ${d.id}`));
   }
 

--- a/handlers/power-level-handler.js
+++ b/handlers/power-level-handler.js
@@ -19,7 +19,7 @@ module.exports = function powerLevelHandler(vera, request) {
 
 function changePowerLevel(d, sData, cInfo, directive, payload, vera) {
   // Verify that the device is capable of power on/off actions
-  if ([2].indexOf(Number(d.category)) === -1) {
+  if (Number(d.category) !== 2) {
     return Promise.reject(utils.error('INVALID_VALUE', `Directive is not supported for this device: ${d.id}`));
   }
 

--- a/handlers/scene-handler.js
+++ b/handlers/scene-handler.js
@@ -25,11 +25,19 @@ function controlScene(s, sData, cInfo, directive, vera) {
     return Promise.reject(utils.error('ENDPOINT_UNREACHABLE', `Endpoint scene is paused: ${s.id}`));
   }
 
-  // TODO: Include support for deactivate scene?
-  return activateScene(s, cInfo, sData, vera);
+  return vera.listScene(cInfo, s.id)
+    .then((sList) => checkSceneSecureDevices(sList))
+    .then(() => activateScene(s, cInfo, vera));
 }
 
-function activateScene(s, cInfo, sData, vera) {
+function checkSceneSecureDevices(sList) {
+  if (utils.sceneHasForbiddenDevices(sList.groups)) {
+    return Promise.reject(utils.error('NO_SUCH_ENDPOINT', 'Scene contains insecure devices'));
+  }
+  return true;
+}
+
+function activateScene(s, cInfo, vera) {
   // Send the scene activation request
   return vera.runScene(cInfo, s.id)
     .then(() => [

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -302,6 +302,12 @@ function getRoomNameFromId(rId, rooms) {
   return (room) ? room.name : null;
 }
 
+function sceneHasForbiddenDevices(groups) {
+  return groups.find((g) => g.actions.find(
+    (a) => a.service.includes(':DoorLock') || a.service.includes(':Camera') || a.service.includes(':SecuritySensor')
+  ));
+}
+
 module.exports = {
   log,
   uuid,
@@ -325,5 +331,6 @@ module.exports = {
   getSwitchDisplayCategory,
   getDimmerDisplayCategory,
   getDisplayCategoryOverride,
-  getRoomNameFromId
+  getRoomNameFromId,
+  sceneHasForbiddenDevices
 };

--- a/lib/vera.js
+++ b/lib/vera.js
@@ -384,6 +384,15 @@ class Vera {
     });
   }
 
+  listScene(cInfo, sId) {
+    return this.dataRequest(cInfo, {
+      'id': 'scene',
+      'action': 'list',
+      'scene': sId,
+      'output_format': 'json'
+    });
+  }
+
   runScene(cInfo, sceneId) {
     return this.dataRequest(cInfo, {
       'id': 'action',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-vera-skill",
-  "version": "1.1.0",
+  "version": "1.2.0-beta",
   "description": "Unofficial custom Smart Home v3 skill for Vera controllers",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Bug fixes
- Fixed: Colored Bulb Device adjust temperature - incorrect error handling when device status is missing

### New features
- Forbids discovery and usage of Scenes that include [insecure devices](https://developer.amazon.com/docs/smarthome/provide-scenes-in-a-smart-home-skill.html#scene-discovery-and-allowed-devices) [#5](https://github.com/cgmartin/custom-vera-skill/pull/5).

### Changes
- Session cache will not be cleared during Discovery in this release. Discovery events occur more frequently than expected - cache helps reduce the lambda execution time for this heavy operation. If this becomes problematic, may need to clear the cache in certain error scenarios.